### PR TITLE
DatabaseModule spanner connection fix

### DIFF
--- a/src/main/java/com/google/finapp/DatabaseModule.java
+++ b/src/main/java/com/google/finapp/DatabaseModule.java
@@ -41,12 +41,12 @@ final class DatabaseModule extends AbstractModule {
     SpannerOptions spannerOptions = SpannerOptions.getDefaultInstance();
     Spanner spanner =
         spannerOptions.toBuilder()
-            .setChannelProvider(
-                // Configure GRPC channel explicitly, to simplify deployment on GKE. The default
-                // configuration requires a grpclb to be available.
-                FixedTransportChannelProvider.create(
-                    GrpcTransportChannel.create(
-                        ManagedChannelBuilder.forAddress(spannerHost, spannerPort).build())))
+            // .setChannelProvider(
+            //     // Configure GRPC channel explicitly, to simplify deployment on GKE. The default
+            //     // configuration requires a grpclb to be available.
+            //     FixedTransportChannelProvider.create(
+            //         GrpcTransportChannel.create(
+            //             ManagedChannelBuilder.forAddress(spannerHost, spannerPort).build())))
             .build()
             .getService();
     return spanner.getDatabaseClient(


### PR DESCRIPTION
commented out a method `setChannelProvider` in the `DatabaseModule.java` class which was trying to connect to real spanner instead of just the local emulator