### PR TITLE
Fix quote character in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ for client libraries to work.
     $ gcloud config set spanner/instance test-instance
     $ gcloud spanner databases create test-database \
         --ddl-file src/main/java/com/google/finapp/schema.sdl
-    $ export SPANNER_EMULATOR_HOST=”localhost:9010"
+    $ export SPANNER_EMULATOR_HOST="localhost:9010"
     ```
 
 2. Bring up the FinAppServer hosting a grpc service.


### PR DESCRIPTION
This PR fixes a typo in the README where a right double quotation mark was used instead of a straight double quotation mark.