### PR TITLE
SpannerDaoException.java class

### DIFF
--- a/src/main/java/com/google/finapp/FinAppService.java
+++ b/src/main/java/com/google/finapp/FinAppService.java
@@ -14,9 +14,9 @@
 
 package com.google.finapp;
 
-import com.google.cloud.spanner.SpannerException;
 import com.google.inject.Inject;
 import com.google.protobuf.Empty;
+import com.google.finapp.SpannerDaoException;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 
@@ -39,7 +39,7 @@ final class FinAppService extends FinAppGrpc.FinAppImplBase {
           UuidConverter.getBytesFromUuid(UUID.randomUUID()),
           customer.getName(),
           customer.getAddress());
-    } catch (SpannerException e) {
+    } catch (SpannerDaoException e) {
       responseObserver.onError(Status.fromThrowable(e).asException());
       return;
     }
@@ -55,7 +55,7 @@ final class FinAppService extends FinAppGrpc.FinAppImplBase {
           toStorageAccountType(account.getType()),
           toStorageAccountStatus(account.getStatus()),
           new BigDecimal(account.getBalance()));
-    } catch (SpannerException e) {
+    } catch (SpannerDaoException e) {
       responseObserver.onError(Status.fromThrowable(e).asException());
       return;
     } catch (NumberFormatException e) {

--- a/src/main/java/com/google/finapp/SpannerDaoException.java
+++ b/src/main/java/com/google/finapp/SpannerDaoException.java
@@ -16,7 +16,7 @@ package com.google.finapp;
 
 public class SpannerDaoException extends Exception {
 
-  public SpannerDaoException(String msg, Throwable err) {
-    super(msg, err);
+  public SpannerDaoException(Exception e) {
+    super(e);
   }
 }

--- a/src/main/java/com/google/finapp/SpannerDaoException.java
+++ b/src/main/java/com/google/finapp/SpannerDaoException.java
@@ -1,0 +1,22 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.finapp;
+
+public class SpannerDaoException extends Exception {
+
+  public SpannerDaoException(String msg, Throwable err) {
+    super(msg, err);
+  }
+}

--- a/src/main/java/com/google/finapp/SpannerDaoImpl.java
+++ b/src/main/java/com/google/finapp/SpannerDaoImpl.java
@@ -47,7 +47,7 @@ final class SpannerDaoImpl implements SpannerDaoInterface {
                   .to(address)
                   .build()));
     } catch (SpannerException e) {
-      throw new SpannerDaoException("SpannerException:", e);
+      throw new SpannerDaoException(e);
     }
   }
 
@@ -71,7 +71,7 @@ final class SpannerDaoImpl implements SpannerDaoInterface {
                   .to(Value.COMMIT_TIMESTAMP)
                   .build()));
     } catch (SpannerException e) {
-      throw new SpannerDaoException("SpannerException:", e);
+      throw new SpannerDaoException(e);
     }
   }
 
@@ -93,7 +93,7 @@ final class SpannerDaoImpl implements SpannerDaoInterface {
                   .to(roleName)
                   .build()));
     } catch (SpannerException e) {
-      throw new SpannerDaoException("SpannerException:", e);
+      throw new SpannerDaoException(e);
     }
   }
 
@@ -122,7 +122,7 @@ final class SpannerDaoImpl implements SpannerDaoInterface {
                 return null;
               });
     } catch (SpannerException e) {
-      throw new SpannerDaoException("SpannerException:", e);
+      throw new SpannerDaoException(e);
     }
   }
 

--- a/src/main/java/com/google/finapp/SpannerDaoImpl.java
+++ b/src/main/java/com/google/finapp/SpannerDaoImpl.java
@@ -18,6 +18,7 @@ import com.google.cloud.ByteArray;
 import com.google.cloud.spanner.*;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.finapp.SpannerDaoException;
 import com.google.inject.Inject;
 
 import java.math.BigDecimal;
@@ -32,7 +33,8 @@ final class SpannerDaoImpl implements SpannerDaoInterface {
   }
 
   @Override
-  public void createCustomer(ByteArray customerId, String name, String address) throws SpannerException {
+  public void createCustomer(ByteArray customerId, String name, String address)
+      throws SpannerDaoException {
     databaseClient.write(
         ImmutableList.of(
             Mutation.newInsertBuilder("Customer")
@@ -48,7 +50,7 @@ final class SpannerDaoImpl implements SpannerDaoInterface {
   @Override
   public void createAccount(
       ByteArray accountId, AccountType accountType, AccountStatus accountStatus, BigDecimal balance)
-      throws SpannerException {
+      throws SpannerDaoException {
     databaseClient.write(
         ImmutableList.of(
             Mutation.newInsertBuilder("Account")
@@ -68,7 +70,7 @@ final class SpannerDaoImpl implements SpannerDaoInterface {
   @Override
   public void addAccountForCustomer(
       ByteArray customerId, ByteArray accountId, ByteArray roleId, String roleName)
-      throws SpannerException {
+      throws SpannerDaoException {
     databaseClient.write(
         ImmutableList.of(
             Mutation.newInsertBuilder("CustomerRole")
@@ -84,7 +86,8 @@ final class SpannerDaoImpl implements SpannerDaoInterface {
   }
 
   @Override
-  public void moveAccountBalance(ByteArray fromAccountId, ByteArray toAccountId, BigDecimal amount) throws SpannerException {
+  public void moveAccountBalance(ByteArray fromAccountId, ByteArray toAccountId, BigDecimal amount)
+      throws SpannerDaoException {
     databaseClient
         .readWriteTransaction()
         .run(

--- a/src/main/java/com/google/finapp/SpannerDaoInterface.java
+++ b/src/main/java/com/google/finapp/SpannerDaoInterface.java
@@ -15,7 +15,7 @@
 package com.google.finapp;
 
 import com.google.cloud.ByteArray;
-import com.google.cloud.spanner.SpannerException;
+import com.google.finapp.SpannerDaoException;
 
 import java.math.BigDecimal;
 
@@ -27,7 +27,7 @@ public interface SpannerDaoInterface {
   /**
    * Inserts a new row to the Customer table in the database.
    */
-  void createCustomer(ByteArray customerId, String name, String address) throws SpannerException;
+  void createCustomer(ByteArray customerId, String name, String address) throws SpannerDaoException;
 
   /**
    * Inserts a new row to the Account table in the database.
@@ -37,14 +37,14 @@ public interface SpannerDaoInterface {
    */
   void createAccount(
       ByteArray accountId, AccountType accountType, AccountStatus accountStatus, BigDecimal balance)
-      throws SpannerException;
+      throws SpannerDaoException;
 
   /**
    * Inserts a new row to the CustomerRole table for a Customer in the database.
    */
   void addAccountForCustomer(
       ByteArray customerId, ByteArray accountId, ByteArray roleId, String roleName)
-      throws SpannerException;
+      throws SpannerDaoException;
 
   /**
    * Moves an amount from one unique account to another unique account for a Customer in the
@@ -56,5 +56,5 @@ public interface SpannerDaoInterface {
    * @param amount amount transferred from fromAccountId to toAccountId
    */
   void moveAccountBalance(ByteArray fromAccountId, ByteArray toAccountId,
-      BigDecimal amount) throws SpannerException;
+      BigDecimal amount) throws SpannerDaoException;
 }


### PR DESCRIPTION
this PR creates a custom exception class so that both java client and JDBC implementations are able to use the `SpannerDaoInterface.java` interface despite throwing different exceptions.

the name of the custom exception is subject to change!

this PR does the following:

- [x] updates `FinAppService` class to now catch `SpannerDaoException`
- [x] updates `SpannerDaoInterface` to now throw `SpannerDaoException`
- [x] updates `SpannerDaoImpl` to now throw `SpannerDaoException` when catching a `SpannerException`
- [x] creates `SpannerDaoException` class