### PR TITLE
Ensure non-negative account balances

### DIFF
--- a/src/main/java/com/google/finapp/SpannerDaoImpl.java
+++ b/src/main/java/com/google/finapp/SpannerDaoImpl.java
@@ -61,7 +61,9 @@ final class SpannerDaoImpl implements SpannerDaoInterface {
       ByteArray accountId, AccountType accountType, AccountStatus accountStatus, BigDecimal balance)
       throws SpannerDaoException {
     if (balance.signum() == -1) {
-      throw new IllegalArgumentException("Account balance cannot be negative");
+      throw new IllegalArgumentException(String.format(
+          "Account balance cannot be negative. accountId: %s, balance: %s", accountId.toString(),
+          balance.toString()));
     }
     try {
       databaseClient.write(
@@ -109,7 +111,8 @@ final class SpannerDaoImpl implements SpannerDaoInterface {
   public void moveAccountBalance(ByteArray fromAccountId, ByteArray toAccountId, BigDecimal amount)
       throws SpannerDaoException {
     if (amount.signum() == -1) {
-      throw new IllegalArgumentException("Amount cannot be negative");
+      throw new IllegalArgumentException(String.format(
+          "Amount transferred cannot be negative. amount: %s", amount.toString()));
     }
     try {
       databaseClient
@@ -123,7 +126,9 @@ final class SpannerDaoImpl implements SpannerDaoInterface {
                 BigDecimal newSourceAmount = accountBalances.get(fromAccountId).subtract(amount);
 
                 if (newSourceAmount.signum() == -1) {
-                  throw new IllegalArgumentException("Account balance cannot be negative");
+                  throw new IllegalArgumentException(String.format(
+                      "Account balance cannot be negative. original account balance: %s, amount transferred: %s",
+                      accountBalances.get(fromAccountId).toString(), amount.toString()));
                 }
 
                 transaction.buffer(

--- a/src/main/java/com/google/finapp/SpannerDaoImpl.java
+++ b/src/main/java/com/google/finapp/SpannerDaoImpl.java
@@ -60,7 +60,7 @@ final class SpannerDaoImpl implements SpannerDaoInterface {
   public void createAccount(
       ByteArray accountId, AccountType accountType, AccountStatus accountStatus, BigDecimal balance)
       throws SpannerDaoException {
-    if (balance.compareTo(BigDecimal.ZERO) < 0) {
+    if (balance.signum() == -1) {
       throw new IllegalArgumentException("Account balance cannot be negative");
     }
     try {
@@ -117,8 +117,7 @@ final class SpannerDaoImpl implements SpannerDaoInterface {
                 ImmutableMap<ByteArray, BigDecimal> accountBalances =
                     readAccountBalances(fromAccountId, toAccountId, transaction);
 
-                if (accountBalances.get(fromAccountId).subtract(amount).compareTo(BigDecimal.ZERO)
-                    < 0) {
+                if (accountBalances.get(fromAccountId).subtract(amount).signum() == -1) {
                   throw new IllegalArgumentException("Account balance cannot be negative");
                 }
 

--- a/src/main/java/com/google/finapp/SpannerDaoImpl.java
+++ b/src/main/java/com/google/finapp/SpannerDaoImpl.java
@@ -120,14 +120,16 @@ final class SpannerDaoImpl implements SpannerDaoInterface {
                 ImmutableMap<ByteArray, BigDecimal> accountBalances =
                     readAccountBalances(fromAccountId, toAccountId, transaction);
 
-                if (accountBalances.get(fromAccountId).subtract(amount).signum() == -1) {
+                BigDecimal newSourceAmount = accountBalances.get(fromAccountId).subtract(amount);
+
+                if (newSourceAmount.signum() == -1) {
                   throw new IllegalArgumentException("Account balance cannot be negative");
                 }
 
                 transaction.buffer(
                     ImmutableList.of(
                         buildUpdateAccountMutation(
-                            fromAccountId, accountBalances.get(fromAccountId).subtract(amount)),
+                            fromAccountId, newSourceAmount),
                         buildUpdateAccountMutation(
                             toAccountId, accountBalances.get(toAccountId).add(amount)),
                         buildInsertTransactionHistoryMutation(

--- a/src/main/java/com/google/finapp/SpannerDaoImpl.java
+++ b/src/main/java/com/google/finapp/SpannerDaoImpl.java
@@ -60,6 +60,9 @@ final class SpannerDaoImpl implements SpannerDaoInterface {
   public void createAccount(
       ByteArray accountId, AccountType accountType, AccountStatus accountStatus, BigDecimal balance)
       throws SpannerDaoException {
+    if (balance.compareTo(BigDecimal.ZERO) < 0) {
+      throw new IllegalArgumentException("Account balance cannot be negative");
+    }
     try {
       databaseClient.write(
           ImmutableList.of(

--- a/src/main/java/com/google/finapp/SpannerDaoImpl.java
+++ b/src/main/java/com/google/finapp/SpannerDaoImpl.java
@@ -15,12 +15,17 @@
 package com.google.finapp;
 
 import com.google.cloud.ByteArray;
-import com.google.cloud.spanner.*;
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.Key;
+import com.google.cloud.spanner.KeySet;
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.SpannerException;
+import com.google.cloud.spanner.TransactionContext;
+import com.google.cloud.spanner.Value;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.finapp.SpannerDaoException;
 import com.google.inject.Inject;
-
 import java.math.BigDecimal;
 
 final class SpannerDaoImpl implements SpannerDaoInterface {
@@ -108,6 +113,11 @@ final class SpannerDaoImpl implements SpannerDaoInterface {
                 // Get account balances.
                 ImmutableMap<ByteArray, BigDecimal> accountBalances =
                     readAccountBalances(fromAccountId, toAccountId, transaction);
+
+                if (accountBalances.get(fromAccountId).subtract(amount).compareTo(BigDecimal.ZERO)
+                    < 0) {
+                  throw new IllegalArgumentException("Account balance cannot be negative");
+                }
 
                 transaction.buffer(
                     ImmutableList.of(

--- a/src/main/java/com/google/finapp/SpannerDaoImpl.java
+++ b/src/main/java/com/google/finapp/SpannerDaoImpl.java
@@ -108,6 +108,9 @@ final class SpannerDaoImpl implements SpannerDaoInterface {
   @Override
   public void moveAccountBalance(ByteArray fromAccountId, ByteArray toAccountId, BigDecimal amount)
       throws SpannerDaoException {
+    if (amount.signum() == -1) {
+      throw new IllegalArgumentException("Amount cannot be negative");
+    }
     try {
       databaseClient
           .readWriteTransaction()

--- a/src/main/java/com/google/finapp/SpannerDaoInterface.java
+++ b/src/main/java/com/google/finapp/SpannerDaoInterface.java
@@ -54,7 +54,7 @@ public interface SpannerDaoInterface {
    * @param fromAccountId unique account id where amount will be transferred from
    * @param toAccountId unique account id where amount will be transferred to
    * @param amount amount transferred from fromAccountId to toAccountId, must be less than or equal
-   * to fromAccountId's account balance
+   * to fromAccountId's account balance, must be non-negative
    */
   void moveAccountBalance(ByteArray fromAccountId, ByteArray toAccountId,
       BigDecimal amount) throws SpannerDaoException;

--- a/src/main/java/com/google/finapp/SpannerDaoInterface.java
+++ b/src/main/java/com/google/finapp/SpannerDaoInterface.java
@@ -30,7 +30,6 @@ public interface SpannerDaoInterface {
   /**
    * Inserts a new row to the Account table in the database.
    *
-   * @param accountId unique id of account
    * @param accountType indicates unspecified, checking, or savings Account type
    * @param accountStatus indicates unspecified, active, or frozen Account status
    * @param balance non-negative account balance

--- a/src/main/java/com/google/finapp/SpannerDaoInterface.java
+++ b/src/main/java/com/google/finapp/SpannerDaoInterface.java
@@ -15,8 +15,6 @@
 package com.google.finapp;
 
 import com.google.cloud.ByteArray;
-import com.google.finapp.SpannerDaoException;
-
 import java.math.BigDecimal;
 
 /**
@@ -32,8 +30,10 @@ public interface SpannerDaoInterface {
   /**
    * Inserts a new row to the Account table in the database.
    *
+   * @param accountId unique id of account
    * @param accountType indicates unspecified, checking, or savings Account type
-   * @param accountStatus indicates unspecificed, active, or frozen Account status
+   * @param accountStatus indicates unspecified, active, or frozen Account status
+   * @param balance non-negative account balance
    */
   void createAccount(
       ByteArray accountId, AccountType accountType, AccountStatus accountStatus, BigDecimal balance)
@@ -53,7 +53,8 @@ public interface SpannerDaoInterface {
    *
    * @param fromAccountId unique account id where amount will be transferred from
    * @param toAccountId unique account id where amount will be transferred to
-   * @param amount amount transferred from fromAccountId to toAccountId
+   * @param amount amount transferred from fromAccountId to toAccountId, must be less than or equal
+   * to fromAccountId's account balance
    */
   void moveAccountBalance(ByteArray fromAccountId, ByteArray toAccountId,
       BigDecimal amount) throws SpannerDaoException;

--- a/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
+++ b/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
@@ -111,6 +111,9 @@ final class SpannerDaoJDBCImpl implements SpannerDaoInterface {
 
   public void moveAccountBalance(ByteArray fromAccountId, ByteArray toAccountId, BigDecimal amount)
       throws SpannerDaoException {
+    if (amount.signum() == -1) {
+      throw new IllegalArgumentException("Amount cannot be negative");
+    }
     try (Connection connection = DriverManager.getConnection(this.connectionUrl);
         PreparedStatement readStatement =
             connection.prepareStatement(

--- a/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
+++ b/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
@@ -131,6 +131,10 @@ final class SpannerDaoJDBCImpl implements SpannerDaoInterface {
       if (sourceAmount == null || destAmount == null) {
         throw new IllegalArgumentException();
       }
+      if (sourceAmount.subtract(amount).compareTo(BigDecimal.ZERO)
+          < 0) {
+        throw new IllegalArgumentException("Account balance cannot be negative");
+      }
       updateAccount(fromAccountIdArray, sourceAmount.subtract(amount), connection);
       updateAccount(toAccountIdArray, destAmount.add(amount), connection);
       insertTransaction(fromAccountIdArray, toAccountIdArray, amount, connection);

--- a/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
+++ b/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
@@ -129,7 +129,7 @@ final class SpannerDaoJDBCImpl implements SpannerDaoInterface {
         }
       }
       if (sourceAmount == null || destAmount == null) {
-        throw new IllegalArgumentException();
+        throw new IllegalArgumentException("Account not found");
       }
       if (sourceAmount.subtract(amount).compareTo(BigDecimal.ZERO)
           < 0) {

--- a/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
+++ b/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
@@ -69,7 +69,7 @@ final class SpannerDaoJDBCImpl implements SpannerDaoInterface {
   public void createAccount(
       ByteArray accountId, AccountType accountType, AccountStatus accountStatus, BigDecimal balance)
       throws SpannerDaoException {
-    if (balance.compareTo(BigDecimal.ZERO) < 0) {
+    if (balance.signum() == -1) {
       throw new IllegalArgumentException("Account balance cannot be negative");
     }
     try (Connection connection = DriverManager.getConnection(this.connectionUrl);
@@ -134,8 +134,7 @@ final class SpannerDaoJDBCImpl implements SpannerDaoInterface {
       if (sourceAmount == null || destAmount == null) {
         throw new IllegalArgumentException("Account not found");
       }
-      if (sourceAmount.subtract(amount).compareTo(BigDecimal.ZERO)
-          < 0) {
+      if (sourceAmount.subtract(amount).signum() == -1) {
         throw new IllegalArgumentException("Account balance cannot be negative");
       }
       updateAccount(fromAccountIdArray, sourceAmount.subtract(amount), connection);

--- a/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
+++ b/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
@@ -137,10 +137,11 @@ final class SpannerDaoJDBCImpl implements SpannerDaoInterface {
       if (sourceAmount == null || destAmount == null) {
         throw new IllegalArgumentException("Account not found");
       }
-      if (sourceAmount.subtract(amount).signum() == -1) {
+      BigDecimal newSourceAmount = sourceAmount.subtract(amount);
+      if (newSourceAmount.signum() == -1) {
         throw new IllegalArgumentException("Account balance cannot be negative");
       }
-      updateAccount(fromAccountIdArray, sourceAmount.subtract(amount), connection);
+      updateAccount(fromAccountIdArray, newSourceAmount, connection);
       updateAccount(toAccountIdArray, destAmount.add(amount), connection);
       insertTransaction(fromAccountIdArray, toAccountIdArray, amount, connection);
       connection.commit();

--- a/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
+++ b/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
@@ -69,6 +69,9 @@ final class SpannerDaoJDBCImpl implements SpannerDaoInterface {
   public void createAccount(
       ByteArray accountId, AccountType accountType, AccountStatus accountStatus, BigDecimal balance)
       throws SpannerDaoException {
+    if (balance.compareTo(BigDecimal.ZERO) < 0) {
+      throw new IllegalArgumentException("Account balance cannot be negative");
+    }
     try (Connection connection = DriverManager.getConnection(this.connectionUrl);
         PreparedStatement ps =
             connection.prepareStatement(


### PR DESCRIPTION
Addresses #12 

This PR ensures that accounts will not have negative balances (at least, with the current supported functions) by checking for: 
- negative inputs to `createAccount` 
- transfer amounts in `moveAccountBalance` that would make an account balance negative

On a separate, related note, this PR also checks for negative inputs to `moveAccountBalance` to enforce that the `IsCredit` bool in `TransactionHistory` is correct (a non-negative amount is being taken from `fromAccount` and given to `toAccount`).

When running code reformatting on this PR, several imports were changed (to improve code style). This includes the removal of unnecessary imports and blank lines and importing specific classes from Cloud Spanner instead of all. 

Accomplished in this PR:
- checks for negative inputs to `createAccount`
- checks for transfer amounts in `moveAccountBalance`
- checks for negative inputs to `moveAccountBalance`
- updates documentation to disallow invalid inputs
- clean up imports in related files