### PR TITLE
Establish test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,10 @@ for client libraries to work.
     $ grpc_cli call localhost:8080 CreateCustomer \
         "name: 'google' address: 'amphitheatre pkwy'"
     ```
+
+## How to run the application tests
+
+1. Set up the emulator as described in #1 above.
+2. Replace the variables in `FinAppTests.setUpTests` according to your chosen instance, project, and database IDs.
+> The default variables should work for instance and database. The project variable must be changed based on `your-project-id` from `gcloud config set project your-project-id`. If this exact command was used, use `"your-project-id"`.
+3. Run `mvn test`.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,4 @@ for client libraries to work.
 ## How to run the application tests
 
 1. Set up the emulator as described in #1 above.
-2. Replace the variables in `FinAppTests.setUpTests` according to your chosen instance, project, and database IDs.
-> The default variables should work for instance and database. The project variable must be changed based on `your-project-id` from `gcloud config set project your-project-id`. If this exact command was used, use `"your-project-id"`.
-3. Run `mvn test`.
+2. Run `mvn test`.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ for client libraries to work.
     $ gcloud emulators spanner start
     $ gcloud config configurations create emulator
     $ gcloud config set auth/disable_credentials true
-    $ gcloud config set project your-project-id
+    $ gcloud config set project test-project
     $ gcloud config set api_endpoint_overrides/spanner http://localhost:9020/
     $ gcloud spanner instances create test-instance \
         --config=emulator-config --description="Test Instance" --nodes=1

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M5</version>
+                <configuration>
+                    <includes>
+                        <include>FinAppIT.java</include>
+                    </includes>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,12 @@
             <artifactId>jcommander</artifactId>
             <version>1.81</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.7.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,6 @@
         </dependency>
     </dependencies>
     <build>
-        <testSourceDirectory>src/test/java/com/google/finapp</testSourceDirectory>
         <extensions>
             <extension>
                 <groupId>kr.motd.maven</groupId>
@@ -119,6 +118,11 @@
                     <source>8</source>
                     <target>8</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
         </dependency>
     </dependencies>
     <build>
+        <testSourceDirectory>src/test/java/com/google/finapp</testSourceDirectory>
         <extensions>
             <extension>
                 <groupId>kr.motd.maven</groupId>

--- a/src/test/java/com/google/finapp/FinAppIT.java
+++ b/src/test/java/com/google/finapp/FinAppIT.java
@@ -32,7 +32,7 @@ import java.util.UUID;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class FinAppTests {
+public class FinAppIT {
 
   private static SpannerDaoInterface JDBCDao;
   private static SpannerDaoInterface JavaDao;

--- a/src/test/java/com/google/finapp/FinAppTests.java
+++ b/src/test/java/com/google/finapp/FinAppTests.java
@@ -39,6 +39,7 @@ public class FinAppTests {
 
   @BeforeClass
   public static void setUpTests() {
+    // set all IDs according to emulator setup
     String spannerProjectId = "test-project";
     String spannerInstanceId = "test-instance";
     String spannerDatabaseId = "test-database";
@@ -56,13 +57,13 @@ public class FinAppTests {
     ByteArray accountIdJava = UuidConverter.getBytesFromUuid(UUID.randomUUID());
     JDBCDao.createAccount(
         accountIdJDBC,
-        AccountType.UNSPECIFIED_ACCOUNT_TYPE,
-        AccountStatus.UNSPECIFIED_ACCOUNT_STATUS,
+        AccountType.UNSPECIFIED_ACCOUNT_TYPE /* = 0*/,
+        AccountStatus.UNSPECIFIED_ACCOUNT_STATUS /* = 0*/,
         new BigDecimal(2));
     JavaDao.createAccount(
         accountIdJava,
-        AccountType.UNSPECIFIED_ACCOUNT_TYPE,
-        AccountStatus.UNSPECIFIED_ACCOUNT_STATUS,
+        AccountType.UNSPECIFIED_ACCOUNT_TYPE /* = 0*/,
+        AccountStatus.UNSPECIFIED_ACCOUNT_STATUS /* = 0*/,
         new BigDecimal(36));
     try (ResultSet resultSet =
         databaseClient

--- a/src/test/java/com/google/finapp/FinAppTests.java
+++ b/src/test/java/com/google/finapp/FinAppTests.java
@@ -16,6 +16,8 @@
 
 package com.google.finapp;
 
+import static org.junit.Assert.assertEquals;
+
 import com.google.cloud.ByteArray;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.DatabaseId;
@@ -27,7 +29,6 @@ import com.google.cloud.spanner.SpannerOptions;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.UUID;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -76,13 +77,13 @@ public class FinAppTests {
       boolean JDBCSeen = false;
       boolean JavaSeen = false;
       while (resultSet.next()) {
-        Assert.assertEquals(0, resultSet.getLong(0));
-        Assert.assertEquals(0, resultSet.getLong(1));
+        assertEquals(0, resultSet.getLong(0));
+        assertEquals(0, resultSet.getLong(1));
         if (resultSet.getBytes(3).equals(accountIdJDBC)) {
-          Assert.assertEquals(new BigDecimal(2), resultSet.getBigDecimal(2));
+          assertEquals(new BigDecimal(2), resultSet.getBigDecimal(2));
           JDBCSeen = true;
         } else if (resultSet.getBytes(3).equals(accountIdJava)) {
-          Assert.assertEquals(new BigDecimal(36), resultSet.getBigDecimal(2));
+          assertEquals(new BigDecimal(36), resultSet.getBigDecimal(2));
           JavaSeen = true;
         }
       }

--- a/src/test/java/com/google/finapp/FinAppTests.java
+++ b/src/test/java/com/google/finapp/FinAppTests.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.finapp;
+
+public class FinAppTests {
+
+}

--- a/src/test/java/com/google/finapp/FinAppTests.java
+++ b/src/test/java/com/google/finapp/FinAppTests.java
@@ -16,6 +16,77 @@
 
 package com.google.finapp;
 
+import com.google.cloud.ByteArray;
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.DatabaseId;
+import com.google.cloud.spanner.Key;
+import com.google.cloud.spanner.KeySet;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.SpannerOptions;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.UUID;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
 public class FinAppTests {
 
+  private static SpannerDaoInterface JDBCDao;
+  private static SpannerDaoInterface JavaDao;
+  private static DatabaseClient databaseClient;
+
+  @BeforeClass
+  public static void setUpTests() {
+    String spannerProjectId = "test-project";
+    String spannerInstanceId = "test-instance";
+    String spannerDatabaseId = "test-database";
+    JDBCDao = new SpannerDaoJDBCImpl(spannerProjectId, spannerInstanceId, spannerDatabaseId);
+    SpannerOptions spannerOptions = SpannerOptions.getDefaultInstance();
+    Spanner spanner = spannerOptions.toBuilder().build().getService();
+    databaseClient = spanner
+        .getDatabaseClient(DatabaseId.of(spannerProjectId, spannerInstanceId, spannerDatabaseId));
+    JavaDao = new SpannerDaoImpl(databaseClient);
+  }
+
+  @Test
+  public void createAccountTest() throws SpannerDaoException {
+    ByteArray accountIdJDBC = UuidConverter.getBytesFromUuid(UUID.randomUUID());
+    ByteArray accountIdJava = UuidConverter.getBytesFromUuid(UUID.randomUUID());
+    JDBCDao.createAccount(
+        accountIdJDBC,
+        AccountType.UNSPECIFIED_ACCOUNT_TYPE,
+        AccountStatus.UNSPECIFIED_ACCOUNT_STATUS,
+        new BigDecimal(2));
+    JavaDao.createAccount(
+        accountIdJava,
+        AccountType.UNSPECIFIED_ACCOUNT_TYPE,
+        AccountStatus.UNSPECIFIED_ACCOUNT_STATUS,
+        new BigDecimal(36));
+    try (ResultSet resultSet =
+        databaseClient
+            .singleUse()
+            .read(
+                "Account",
+                KeySet.newBuilder().addKey(Key.of(accountIdJDBC)).addKey(Key.of(accountIdJava))
+                    .build(),
+                Arrays.asList("AccountType", "AccountStatus", "Balance", "AccountId"))) {
+      boolean JDBCSeen = false;
+      boolean JavaSeen = false;
+      while (resultSet.next()) {
+        Assert.assertEquals(0, resultSet.getLong(0));
+        Assert.assertEquals(0, resultSet.getLong(1));
+        if (resultSet.getBytes(3).equals(accountIdJDBC)) {
+          Assert.assertEquals(new BigDecimal(2), resultSet.getBigDecimal(2));
+          JDBCSeen = true;
+        } else if (resultSet.getBytes(3).equals(accountIdJava)) {
+          Assert.assertEquals(new BigDecimal(36), resultSet.getBigDecimal(2));
+          JavaSeen = true;
+        }
+      }
+      assert JDBCSeen;
+      assert JavaSeen;
+    }
+  }
 }


### PR DESCRIPTION
This PR establishes a test suite for the financial app. This PR does not create tests for all current methods; it only sets up a framework with one example. 

In its current state, the tests assume that the user has an emulator running in a separate terminal and has set up the string variables for project, instance, and database IDs.

This PR is also just a start to setting up tests. More work will be done on improving the tests, but this provides a baseline. 

Accomplished in this PR:
- set up test file
- create first method IT 
- add plugin to enable `mvn test`
- update README to give instructions for running tests