### PR TITLE
Add coveooss/fmt-maven-plugin to repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,18 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.coveo</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>2.11</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Uses the default setting at https://github.com/coveooss/fmt-maven-plugin to format code using google-java-format on each build.