### PR TITLE
GetRecentTransactionsForAccount rpc

### DIFF
--- a/src/main/java/com/google/finapp/FinAppService.java
+++ b/src/main/java/com/google/finapp/FinAppService.java
@@ -15,6 +15,8 @@
 package com.google.finapp;
 
 import com.google.cloud.ByteArray;
+import com.google.cloud.Timestamp;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.protobuf.ByteString;
@@ -135,6 +137,33 @@ final class FinAppService extends FinAppGrpc.FinAppImplBase {
         MoveAccountBalanceResponse.newBuilder()
             .setFromAccountIdBalance(accountBalances.get(fromAccountId).toString())
             .setToAccountIdBalance(accountBalances.get(toAccountId).toString())
+            .build();
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void getRecentTransactionsForAccount(
+      GetRecentTransactionsForAccountRequest request,
+      StreamObserver<GetRecentTransactionsForAccountResponse> responseObserver) {
+    ImmutableList<TransactionEntry> transactionEntries;
+    ByteArray accountId = ByteArray.copyFrom(request.getAccountId().toByteArray());
+    Timestamp beginTimestamp =
+        Timestamp.ofTimeSecondsAndNanos(
+            request.getBeginTimestamp().getSeconds(), request.getBeginTimestamp().getNanos());
+    Timestamp endTimestamp =
+        Timestamp.ofTimeSecondsAndNanos(
+            request.getEndTimestamp().getSeconds(), request.getEndTimestamp().getNanos());
+    try {
+      transactionEntries =
+          spannerDao.getRecentTransactionsForAccount(accountId, beginTimestamp, endTimestamp);
+    } catch (SpannerDaoException e) {
+      responseObserver.onError(Status.fromThrowable(e).asException());
+      return;
+    }
+    GetRecentTransactionsForAccountResponse response =
+        GetRecentTransactionsForAccountResponse.newBuilder()
+            .addAllTransactionEntry(transactionEntries)
             .build();
     responseObserver.onNext(response);
     responseObserver.onCompleted();

--- a/src/main/java/com/google/finapp/SpannerDaoImpl.java
+++ b/src/main/java/com/google/finapp/SpannerDaoImpl.java
@@ -189,15 +189,17 @@ final class SpannerDaoImpl implements SpannerDaoInterface {
   private ImmutableList<TransactionEntry> readTransactionHistories(ResultSet resultSet) {
     ImmutableList.Builder<TransactionEntry> transactionHistoriesBuilder = ImmutableList.builder();
     while (resultSet.next()) {
-      transactionHistoriesBuilder.add(TransactionEntry.newBuilder()
-          .setAccountId(ByteString.copyFrom(resultSet.getBytes("AccountId").toByteArray()))
-          .setEventTimestamp(com.google.finapp.Timestamp.newBuilder()
-              .setNanos(resultSet.getTimestamp("EventTimestamp").getNanos())
-              .setSeconds(resultSet.getTimestamp("EventTimestamp").getSeconds()))
-          .setIsCredit(resultSet.getBoolean("IsCredit"))
-          .setAmount(resultSet.getString("Amount"))
-          .setDescription(resultSet.getString("Description"))
-          .build());
+      transactionHistoriesBuilder.add(
+          TransactionEntry.newBuilder()
+              .setAccountId(ByteString.copyFrom(resultSet.getBytes("AccountId").toByteArray()))
+              .setEventTimestamp(
+                  com.google.finapp.Timestamp.newBuilder()
+                      .setNanos(resultSet.getTimestamp("EventTimestamp").getNanos())
+                      .setSeconds(resultSet.getTimestamp("EventTimestamp").getSeconds()))
+              .setIsCredit(resultSet.getBoolean("IsCredit"))
+              .setAmount(resultSet.getString("Amount"))
+              .setDescription(resultSet.getString("Description"))
+              .build());
     }
     return transactionHistoriesBuilder.build();
   }

--- a/src/main/java/com/google/finapp/SpannerDaoImpl.java
+++ b/src/main/java/com/google/finapp/SpannerDaoImpl.java
@@ -179,7 +179,9 @@ final class SpannerDaoImpl implements SpannerDaoInterface {
                               + "FROM TransactionHistory "
                               + "WHERE AccountId = %s AND EventTimestamp BETWEEN %s AND %s "
                               + "ORDER BY EventTimestamp",
-                          accountId, beginTimestamp, endTimestamp)));
+                          accountId.toString(),
+                          beginTimestamp.toString(),
+                          endTimestamp.toString())));
       return readTransactionHistories(resultSet);
     } catch (SpannerException e) {
       throw new SpannerDaoException(e);

--- a/src/main/java/com/google/finapp/SpannerDaoImpl.java
+++ b/src/main/java/com/google/finapp/SpannerDaoImpl.java
@@ -15,6 +15,7 @@
 package com.google.finapp;
 
 import com.google.cloud.ByteArray;
+import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.KeySet;
@@ -148,6 +149,10 @@ final class SpannerDaoImpl implements SpannerDaoInterface {
       throw new SpannerDaoException(e);
     }
   }
+
+  @Override
+  public void getRecentTransactionsForAccount(ByteArray accountId, Timestamp sinceTimestamp)
+      throws SpannerDaoException {}
 
   private ImmutableMap<ByteArray, BigDecimal> readAccountBalances(
       ByteArray fromAccountId, ByteArray toAccountId, TransactionContext transaction) {

--- a/src/main/java/com/google/finapp/SpannerDaoInterface.java
+++ b/src/main/java/com/google/finapp/SpannerDaoInterface.java
@@ -16,6 +16,7 @@ package com.google.finapp;
 
 import com.google.cloud.ByteArray;
 import com.google.cloud.Timestamp;
+import com.google.common.collect.ImmutableList;
 import java.math.BigDecimal;
 
 /** The SpannerDaoInterface defines the methods to be used by its separate implementations. */
@@ -58,8 +59,9 @@ public interface SpannerDaoInterface {
    *
    * @param beginTimestamp timestamp for where query begins
    * @param endTimestamp timestamp for where query ends, default will be most recent transaction
+   * @returns ImmutableList of TransactionEntry objects from the range of timestamps given
    */
-  void getRecentTransactionsForAccount(
+  ImmutableList<TransactionEntry> getRecentTransactionsForAccount(
       ByteArray accountId, Timestamp beginTimestamp, Timestamp endTimestamp)
       throws SpannerDaoException;
 }

--- a/src/main/java/com/google/finapp/SpannerDaoInterface.java
+++ b/src/main/java/com/google/finapp/SpannerDaoInterface.java
@@ -54,10 +54,10 @@ public interface SpannerDaoInterface {
       throws SpannerDaoException;
 
   /**
-   * Uses
+   * Uses accountId to fetch transaction history based on timestamps.
    *
    * @param sinceTimestamp
    */
-  void getRecentTransactionsForAccount(ByteArray accountId, Timestamp sinceTimestamp)
+  void getRecentTransactionsForAccount(ByteArray accountId, Timestamp beginTimestamp, Timestamp endTimestamp)
       throws SpannerDaoException;
 }

--- a/src/main/java/com/google/finapp/SpannerDaoInterface.java
+++ b/src/main/java/com/google/finapp/SpannerDaoInterface.java
@@ -15,6 +15,7 @@
 package com.google.finapp;
 
 import com.google.cloud.ByteArray;
+import com.google.cloud.Timestamp;
 import java.math.BigDecimal;
 
 /** The SpannerDaoInterface defines the methods to be used by its separate implementations. */
@@ -50,5 +51,13 @@ public interface SpannerDaoInterface {
    *     to fromAccountId's account balance, must be non-negative
    */
   void moveAccountBalance(ByteArray fromAccountId, ByteArray toAccountId, BigDecimal amount)
+      throws SpannerDaoException;
+
+  /**
+   * Uses
+   *
+   * @param sinceTimestamp
+   */
+  void getRecentTransactionsForAccount(ByteArray accountId, Timestamp sinceTimestamp)
       throws SpannerDaoException;
 }

--- a/src/main/java/com/google/finapp/SpannerDaoInterface.java
+++ b/src/main/java/com/google/finapp/SpannerDaoInterface.java
@@ -54,10 +54,12 @@ public interface SpannerDaoInterface {
       throws SpannerDaoException;
 
   /**
-   * Uses accountId to fetch transaction history based on timestamps.
+   * Uses accountId to fetch TransactionHistory based on range pf timestamps.
    *
-   * @param sinceTimestamp
+   * @param beginTimestamp timestamp for where query begins
+   * @param endTimestamp timestamp for where query ends, default will be most recent transaction
    */
-  void getRecentTransactionsForAccount(ByteArray accountId, Timestamp beginTimestamp, Timestamp endTimestamp)
+  void getRecentTransactionsForAccount(
+      ByteArray accountId, Timestamp beginTimestamp, Timestamp endTimestamp)
       throws SpannerDaoException;
 }

--- a/src/main/java/com/google/finapp/SpannerDaoInterface.java
+++ b/src/main/java/com/google/finapp/SpannerDaoInterface.java
@@ -53,7 +53,7 @@ public interface SpannerDaoInterface {
    * @return mapping of both accounts' balances after the transfer was made, keyed by id
    */
   ImmutableMap<ByteArray, BigDecimal> moveAccountBalance(
-          ByteArray fromAccountId, ByteArray toAccountId, BigDecimal amount) throws SpannerDaoException;
+      ByteArray fromAccountId, ByteArray toAccountId, BigDecimal amount) throws SpannerDaoException;
 
   /**
    * Uses accountId to fetch TransactionHistory based on range pf timestamps.

--- a/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
+++ b/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
@@ -179,7 +179,6 @@ final class SpannerDaoJDBCImpl implements SpannerDaoInterface {
                     + "FROM TransactionHistory "
                     + "WHERE AccountId = ? AND EventTimestamp BETWEEN ? AND ? "
                     + "ORDER BY EventTimestamp")) {
-      connection.setAutoCommit(false);
       byte[] accountIdArray = accountId.toByteArray();
       java.sql.Timestamp javaBeginTimestamp = beginTimestamp.toSqlTimestamp();
       java.sql.Timestamp javaEndTimestamp = endTimestamp.toSqlTimestamp();

--- a/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
+++ b/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
@@ -15,6 +15,7 @@
 package com.google.finapp;
 
 import com.google.cloud.ByteArray;
+import com.google.cloud.Timestamp;
 import com.google.inject.Inject;
 import java.math.BigDecimal;
 import java.sql.Connection;
@@ -160,6 +161,9 @@ final class SpannerDaoJDBCImpl implements SpannerDaoInterface {
       throw new SpannerDaoException(e);
     }
   }
+
+  public void getRecentTransactionsForAccount(ByteArray accountId, Timestamp sinceTimestamp)
+      throws SpannerDaoException {}
 
   private void updateAccount(byte[] accountId, BigDecimal newBalance, Connection connection)
       throws SQLException {

--- a/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
+++ b/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
@@ -189,15 +189,17 @@ final class SpannerDaoJDBCImpl implements SpannerDaoInterface {
       ResultSet resultSet = readStatement.executeQuery();
       ImmutableList.Builder<TransactionEntry> transactionHistoriesBuilder = ImmutableList.builder();
       while (resultSet.next()) {
-        transactionHistoriesBuilder.add(TransactionEntry.newBuilder()
-            .setAccountId(ByteString.copyFrom(resultSet.getBytes("AccountId")))
-            .setEventTimestamp(com.google.finapp.Timestamp.newBuilder()
-                .setNanos(resultSet.getTimestamp("EventTimestamp").getNanos())
-                .setSeconds(resultSet.getTimestamp("EventTimestamp").getSeconds()))
-            .setIsCredit(resultSet.getBoolean("IsCredit"))
-            .setAmount(resultSet.getString("Amount"))
-            .setDescription(resultSet.getString("Description"))
-            .build());
+        transactionHistoriesBuilder.add(
+            TransactionEntry.newBuilder()
+                .setAccountId(ByteString.copyFrom(resultSet.getBytes("AccountId")))
+                .setEventTimestamp(
+                    com.google.finapp.Timestamp.newBuilder()
+                        .setNanos(resultSet.getTimestamp("EventTimestamp").getNanos())
+                        .setSeconds(resultSet.getTimestamp("EventTimestamp").getSeconds()))
+                .setIsCredit(resultSet.getBoolean("IsCredit"))
+                .setAmount(resultSet.getString("Amount"))
+                .setDescription(resultSet.getString("Description"))
+                .build());
       }
       return transactionHistoriesBuilder.build();
     } catch (SQLException e) {

--- a/src/main/proto/service.proto
+++ b/src/main/proto/service.proto
@@ -69,3 +69,26 @@ message CreateCustomerRoleRequest {
 message CreateCustomerRoleResponse {
   optional bytes role_id = 1;
 }
+
+message Timestamp {
+  required int64 seconds = 1;
+  required int32 nanos = 2;
+}
+
+message TransactionEntry {
+  optional bytes account_id = 1;
+  optional Timestamp event_timestamp = 2;
+  optional bool is_credit = 3;
+  optional string amount = 4;
+  optional string description = 5;
+}
+
+message GetRecentTransactionsForAccountRequest {
+  optional bytes account_id = 1;
+  optional Timestamp begin_timestamp = 2;
+  optional Timestamp end_timestamp = 3;
+}
+
+message GetRecentTransactionsForAccountResponse {
+  repeated TransactionEntry transaction_entry = 1;
+}

--- a/src/main/proto/service.proto
+++ b/src/main/proto/service.proto
@@ -29,6 +29,8 @@ service FinApp {
   rpc CreateCustomerRole(CreateCustomerRoleRequest) returns (CreateCustomerRoleResponse) {}
 
   rpc MoveAccountBalance(MoveAccountBalanceRequest) returns (MoveAccountBalanceResponse) {}
+
+  rpc GetRecentTransactionHistoryForAccount(GetRecentTransactionsForAccountRequest) returns (GetRecentTransactionsForAccountResponse) {}
 }
 
 message CreateCustomerRequest {

--- a/src/main/proto/service.proto
+++ b/src/main/proto/service.proto
@@ -30,7 +30,7 @@ service FinApp {
 
   rpc MoveAccountBalance(MoveAccountBalanceRequest) returns (MoveAccountBalanceResponse) {}
 
-  rpc GetRecentTransactionHistoryForAccount(GetRecentTransactionsForAccountRequest) returns (GetRecentTransactionsForAccountResponse) {}
+  rpc GetRecentTransactionsForAccount(GetRecentTransactionsForAccountRequest) returns (GetRecentTransactionsForAccountResponse) {}
 }
 
 message CreateCustomerRequest {


### PR DESCRIPTION
This PR creates the last rpc outlined in the MVP. This executes a query of all the transactions based on timestamps and returns them in a repeated attribute. 

This PR does the following:

- [x] adds new method to `SpannerDaoInterface`
- [x] adds new method to `SpannerDaoImpl` and `SpannerDaoJDBCImpl` to return `ImmutableList` of `TransactionEntry` types
- [x] adds new rpc to `service.proto`
- [x] adds method to `FinAppService`

This PR does not have:

- tests
