### PR TITLE
Transitioning RPCs to use strings instead of bytes

### DIFF
--- a/server/src/main/java/com/google/finapp/FinAppService.java
+++ b/server/src/main/java/com/google/finapp/FinAppService.java
@@ -51,9 +51,7 @@ final class FinAppService extends FinAppGrpc.FinAppImplBase {
       return;
     }
     CreateCustomerResponse response =
-        CreateCustomerResponse.newBuilder()
-            .setCustomerId(ByteString.copyFrom(customerId.toByteArray()))
-            .build();
+        CreateCustomerResponse.newBuilder().setCustomerId(customerId.toStringUtf8()).build();
     responseObserver.onNext(response);
     responseObserver.onCompleted();
   }
@@ -83,7 +81,7 @@ final class FinAppService extends FinAppGrpc.FinAppImplBase {
     }
     CreateAccountResponse response =
         CreateAccountResponse.newBuilder()
-            .setAccountId(ByteString.copyFrom(accountId.toByteArray()))
+            .setAccountId(accountId.toStringUtf8())
             .build();
     responseObserver.onNext(response);
     responseObserver.onCompleted();
@@ -95,8 +93,8 @@ final class FinAppService extends FinAppGrpc.FinAppImplBase {
     ByteArray roleId = UuidConverter.getBytesFromUuid(UUID.randomUUID());
     try {
       spannerDao.createCustomerRole(
-          ByteArray.copyFrom(role.getCustomerId().toByteArray()),
-          ByteArray.copyFrom(role.getAccountId().toByteArray()),
+          ByteArray.copyFrom(role.getCustomerId()),
+          ByteArray.copyFrom(role.getAccountId()),
           roleId,
           role.getName());
     } catch (SpannerDaoException e) {
@@ -104,9 +102,7 @@ final class FinAppService extends FinAppGrpc.FinAppImplBase {
       return;
     }
     CreateCustomerRoleResponse response =
-        CreateCustomerRoleResponse.newBuilder()
-            .setRoleId(ByteString.copyFrom(roleId.toByteArray()))
-            .build();
+        CreateCustomerRoleResponse.newBuilder().setRoleId(roleId.toStringUtf8()).build();
     responseObserver.onNext(response);
     responseObserver.onCompleted();
   }
@@ -116,12 +112,17 @@ final class FinAppService extends FinAppGrpc.FinAppImplBase {
       MoveAccountBalanceRequest request,
       StreamObserver<MoveAccountBalanceResponse> responseObserver) {
     ImmutableMap<ByteArray, BigDecimal> accountBalances;
-    ByteArray fromAccountId = ByteArray.copyFrom(request.getFromAccountId().toByteArray());
-    ByteArray toAccountId = ByteArray.copyFrom(request.getToAccountId().toByteArray());
+    System.out.println(request.getToAccountId().getBytes());
+    System.out.println(request.getFromAccountId());
+    ByteArray fromAccountId = ByteArray.copyFrom(request.getFromAccountId());
+    ByteArray toAccountId = ByteArray.copyFrom(request.getToAccountId());
+    System.out.println(toAccountId);
+    System.out.println(fromAccountId);
     try {
       accountBalances =
           spannerDao.moveAccountBalance(
               fromAccountId, toAccountId, new BigDecimal(request.getAmount()));
+      System.out.println("i made it here");
     } catch (SpannerDaoException e) {
       responseObserver.onError(Status.fromThrowable(e).asException());
       return;
@@ -156,7 +157,7 @@ final class FinAppService extends FinAppGrpc.FinAppImplBase {
     try {
       newBalance =
           spannerDao.createTransactionForAccount(
-              ByteArray.copyFrom(request.getAccountId().toByteArray()),
+              ByteArray.copyFrom(request.getAccountId()),
               new BigDecimal(request.getAmount()),
               request.getIsCredit());
     } catch (SpannerDaoException e) {
@@ -188,7 +189,7 @@ final class FinAppService extends FinAppGrpc.FinAppImplBase {
       GetRecentTransactionsForAccountRequest request,
       StreamObserver<GetRecentTransactionsForAccountResponse> responseObserver) {
     ImmutableList<TransactionEntry> transactionEntries;
-    ByteArray accountId = ByteArray.copyFrom(request.getAccountId().toByteArray());
+    ByteArray accountId = ByteArray.copyFrom(request.getAccountId());
     Timestamp beginTimestamp = Timestamp.fromProto(request.getBeginTimestamp());
     Timestamp endTimestamp = Timestamp.fromProto(request.getEndTimestamp());
     try {

--- a/server/src/main/java/com/google/finapp/SpannerDaoImpl.java
+++ b/server/src/main/java/com/google/finapp/SpannerDaoImpl.java
@@ -28,7 +28,6 @@ import com.google.cloud.spanner.Value;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
-import com.google.protobuf.ByteString;
 import java.math.BigDecimal;
 
 final class SpannerDaoImpl implements SpannerDaoInterface {
@@ -252,7 +251,7 @@ final class SpannerDaoImpl implements SpannerDaoInterface {
       while (resultSet.next()) {
         transactionHistoriesBuilder.add(
             TransactionEntry.newBuilder()
-                .setAccountId(ByteString.copyFrom(resultSet.getBytes("AccountId").toByteArray()))
+                .setAccountId(resultSet.getBytes("AccountId").toStringUtf8())
                 .setEventTimestamp(resultSet.getTimestamp("EventTimestamp").toProto())
                 .setIsCredit(resultSet.getBoolean("IsCredit"))
                 .setAmount(resultSet.getBigDecimal("Amount").toString())

--- a/server/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
+++ b/server/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
@@ -19,7 +19,6 @@ import com.google.cloud.Timestamp;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
-import com.google.protobuf.ByteString;
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -237,7 +236,7 @@ final class SpannerDaoJDBCImpl implements SpannerDaoInterface {
       while (resultSet.next()) {
         transactionHistoriesBuilder.add(
             TransactionEntry.newBuilder()
-                .setAccountId(ByteString.copyFrom(resultSet.getBytes("AccountId")))
+                .setAccountId(resultSet.getBytes("AccountId").toString())
                 .setEventTimestamp(
                     // use a builder to set com.google.protobuf.Timestamp from java.sql.Timestamp
                     // object

--- a/server/src/main/proto/service.proto
+++ b/server/src/main/proto/service.proto
@@ -51,7 +51,7 @@ message CreateCustomerRequest {
 }
 
 message CreateCustomerResponse {
-  optional bytes customer_id = 1;
+  optional string customer_id = 1; // UTF-8
 }
 
 message CreateAccountRequest {
@@ -73,22 +73,22 @@ message CreateAccountRequest {
 }
 
 message CreateAccountResponse {
-  optional bytes account_id = 1;
+  optional string account_id = 1; // UTF-8
 }
 
 message CreateCustomerRoleRequest {
-  optional bytes customer_id = 1;
-  optional bytes account_id = 2;
+  optional string customer_id = 1; // UTF-8
+  optional string account_id = 2; // UTF-8
   optional string name = 3;
 }
 
 message CreateCustomerRoleResponse {
-  optional bytes role_id = 1;
+  optional string role_id = 1; // UTF-8
 }
 
 message MoveAccountBalanceRequest {
-  optional bytes from_account_id = 1;
-  optional bytes to_account_id = 2;
+  optional string from_account_id = 1; // UTF-8
+  optional string to_account_id = 2; // UTF-8
   optional string amount = 3; // Digits[.[Digits]] or [Digits].Digits
 }
 
@@ -98,7 +98,7 @@ message MoveAccountBalanceResponse {
 }
 
 message CreateTransactionForAccountRequest {
-  optional bytes account_id = 1;
+  optional string account_id = 1; // UTF-8
   optional string amount = 2; // Digits[.[Digits]] or [Digits].Digits
   optional bool is_credit = 3;
 }
@@ -108,14 +108,14 @@ message CreateTransactionForAccountResponse {
 }
 
 message TransactionEntry {
-  optional bytes account_id = 1;
+  optional string account_id = 1; // UTF-8
   optional .google.protobuf.Timestamp event_timestamp = 2;
   optional bool is_credit = 3;
   optional string amount = 4;
 }
 
 message GetRecentTransactionsForAccountRequest {
-  optional bytes account_id = 1;
+  optional string account_id = 1; // UTF-8
   optional .google.protobuf.Timestamp begin_timestamp = 2;
   optional .google.protobuf.Timestamp end_timestamp = 3;
 }

--- a/server/src/test/java/com/google/finapp/FinAppIT.java
+++ b/server/src/test/java/com/google/finapp/FinAppIT.java
@@ -34,7 +34,6 @@ import com.google.cloud.spanner.Value;
 import com.google.cloud.spanner.testing.RemoteSpannerHelper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.protobuf.ByteString;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -538,7 +537,7 @@ public class FinAppIT {
             fromAccountId, Timestamp.MIN_VALUE, Timestamp.MAX_VALUE);
     TransactionEntry expected_transaction =
         TransactionEntry.newBuilder()
-            .setAccountId(ByteString.copyFrom(fromAccountId.toByteArray()))
+            .setAccountId(fromAccountId.toString())
             .setEventTimestamp(history.get(0).getEventTimestamp())
             .setIsCredit(true)
             .setAmount(amount.toString())
@@ -589,21 +588,21 @@ public class FinAppIT {
             fromAccountId, Timestamp.MIN_VALUE, Timestamp.MAX_VALUE);
     TransactionEntry expected_transaction1 =
         TransactionEntry.newBuilder()
-            .setAccountId(ByteString.copyFrom(fromAccountId.toByteArray()))
+            .setAccountId(fromAccountId.toString())
             .setEventTimestamp(history.get(2).getEventTimestamp())
             .setIsCredit(true)
             .setAmount(amount.toString())
             .build();
     TransactionEntry expected_transaction2 =
         TransactionEntry.newBuilder()
-            .setAccountId(ByteString.copyFrom(fromAccountId.toByteArray()))
+            .setAccountId(fromAccountId.toString())
             .setEventTimestamp(history.get(1).getEventTimestamp())
             .setIsCredit(false)
             .setAmount(amount.toString())
             .build();
     TransactionEntry expected_transaction3 =
         TransactionEntry.newBuilder()
-            .setAccountId(ByteString.copyFrom(fromAccountId.toByteArray()))
+            .setAccountId(fromAccountId.toString())
             .setEventTimestamp(history.get(0).getEventTimestamp())
             .setIsCredit(true)
             .setAmount(amount.toString())


### PR DESCRIPTION
Attempts #32

**_NOTE: this branch as it is produces errors when trying to call RPCs that use IDs in their requests. Error described below._**

This branch attempts to address the transition from bytes to strings when taking requested IDs and returning generated IDs. 

- [x] changes all `bytes` to `string` in `service.proto`
- [x] changes responses in `FinAppService` to return strings using method `.toStringUtf8()`
- [x] changes `getRecentTransactionsForAccount` methods in Java Client and JDBC impls to update `TransactionHistory` using `toStringUtf8` and `toString` methods when setting ids
- [x] updates test to reflect those changes

**problem has been narrowed down to here (through debugging and printing out lists and ids):**
when calling `readAccountBalances(fromAccountId, toAccoundId, transaction)` (lines 129 and 130) in `SpannerDaoImpl`, the map is empty, meaning it did not find the accounts using the IDs provided from the request. before switching from bytes to strings, this map held the accounts found. 

**important to note:**
when printing out the same ID as a `ByteString` and then as a `string`, they are different. 
```
$ grpc_cli call localhost:8080 CreateAccount "balance: '10000' type: CHECKING status: ACTIVE" --channel_creds_type=insecure
connecting to localhost:8080
account_id: "\304\252\357\277\275?\357\277\275B\357\277\275\357\277\275\357\277\2750\n\'PY\357\277\275"
account_id_again: "\304\252\357\265?\357B\227\225\3160\n\'PY\256"
```
`account_id` is the ByteString, `accound_id_again` is the same ID but using the `toStringUtf8()` method. I returned it using the `toStringUtf8()` because from the [documentation](https://googleapis.dev/java/google-cloud-clients/latest/com/google/cloud/ByteArray.html#copyFrom-java.lang.String-) i read, `ByteArray`s can be created from strings if they are in UTF-8, so it seemed like the correct way to go about it, but I think some important characters from the ID are being lost and doing `copyFrom(xx)` is not creating the correct ID.

current errors:
```
$ grpc_cli call localhost:8080 MoveAccountBalance "from_account_id: '\357\277\275\357\277\275j\014\357\277\275\357\277\275Lu\357\277\275\357\277\275~\033q\357\277\275\357\277\275\357\277\275' to_account_id: '\357\277\275\006;\357\277\275\013\357\277\275A\322\201\316\221\021k\357\277\275$\r' amount: '4000'" --channel_creds_type=insecure
connecting to localhost:8080
Rpc failed with status code 2, error message: 
```
