### PR TITLE
Workflow improvements

### DIFF
--- a/.github/workflows/ci-emulator.yaml
+++ b/.github/workflows/ci-emulator.yaml
@@ -25,13 +25,13 @@ jobs:
     - run: gcloud config set project test-project
     - run: gcloud config set api_endpoint_overrides/spanner http://localhost:9020/
     - run: gcloud spanner instances create test-instance --config=emulator-config --nodes=1 --description="TestInstance"
-    - run: mvn clean compile
-    - run: mvn integration-test failsafe:verify
+    - run: mvn --batch-mode clean compile
+    - run: mvn --batch-mode integration-test failsafe:verify
       env:
         JOB_TYPE: test
         SPANNER_EMULATOR_HOST: localhost:9010
         GOOGLE_CLOUD_PROJECT: test-project
-    - run: mvn integration-test failsafe:verify -DSPANNER_USE_JDBC=true
+    - run: mvn --batch-mode integration-test failsafe:verify -DSPANNER_USE_JDBC=true
       env:
         JOB_TYPE: test
         SPANNER_EMULATOR_HOST: localhost:9010

--- a/.github/workflows/ci-emulator.yaml
+++ b/.github/workflows/ci-emulator.yaml
@@ -17,15 +17,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v2
       with:
         java-version: 11
+        distribution: 'adopt'
+        cache: 'maven'
     - run: java -version
     - run: gcloud config set auth/disable_credentials true
     - run: gcloud config set project test-project
     - run: gcloud config set api_endpoint_overrides/spanner http://localhost:9020/
     - run: gcloud spanner instances create test-instance --config=emulator-config --nodes=1 --description="TestInstance"
-    - run: mvn --batch-mode clean compile
     - run: mvn --batch-mode integration-test failsafe:verify
       env:
         JOB_TYPE: test

--- a/.github/workflows/ci-emulator.yaml
+++ b/.github/workflows/ci-emulator.yaml
@@ -29,9 +29,7 @@ jobs:
     - run: gcloud config set api_endpoint_overrides/spanner http://localhost:9020/
     - run: gcloud spanner instances create test-instance --config=emulator-config --nodes=1 --description="TestInstance"
     - run: export SPANNER_EMULATOR_HOST="localhost:9010"
-    - run: mvn clean compile
-    - run: mvn integration-test
-    - run: mvn integration-test -DSPANNER_USE_JDBC=true
+    - run: mvn verify
   
       env:
         JOB_TYPE: test

--- a/.github/workflows/ci-emulator.yaml
+++ b/.github/workflows/ci-emulator.yaml
@@ -29,7 +29,7 @@ jobs:
     - run: gcloud config set api_endpoint_overrides/spanner http://localhost:9020/
     - run: gcloud spanner instances create test-instance --config=emulator-config --nodes=1 --description="TestInstance"
     - run: export SPANNER_EMULATOR_HOST="localhost:9010"
-    - run: mvn verify
+    - run: mvn -B verify
   
       env:
         JOB_TYPE: test

--- a/.github/workflows/ci-emulator.yaml
+++ b/.github/workflows/ci-emulator.yaml
@@ -17,9 +17,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: stCarolas/setup-maven@v4
-      with:
-        maven-version: 3.8.1
     - uses: actions/setup-java@v1
       with:
         java-version: 11

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -151,7 +151,6 @@
                     <execution>
                         <goals>
                             <goal>integration-test</goal>
-                            <goal>verify</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -151,6 +151,7 @@
                     <execution>
                         <goals>
                             <goal>integration-test</goal>
+                            <goal>verify</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
Minor changes to https://github.com/GoogleCloudPlatform/cloud-spanner-samples/pull/61 following https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven:
- use `--batch-mode` to suppress progress logs
- cache maven dependencies to avoid downloading the world with each run
- drop the `setup-maven` action in favor of `setup-java`'s built-in maven version