### PR TITLE
Fix version discrepancy in grpc deps by using bom in root pom

### DIFF
--- a/.github/workflows/ci-workload-build.yaml
+++ b/.github/workflows/ci-workload-build.yaml
@@ -1,0 +1,23 @@
+name: Build workload module
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: 11
+        distribution: 'adopt'
+        cache: 'maven'
+    - name: Build workload project with Maven
+      run: |
+        mvn clean install -DskipTests
+        mvn compile assembly:single -pl org.example:workload

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="http://maven.apache.org/POM/4.0.0"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -20,8 +18,20 @@
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <grpc.version>1.38.0</grpc.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-bom</artifactId>
+                <version>${grpc.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <extensions>
             <extension>
@@ -55,6 +65,28 @@
                 </executions>
                 <groupId>com.coveo</groupId>
                 <version>2.11</version>
+            </plugin>
+            <plugin>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <configuration>
+                    <pluginArtifact>
+                        io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}
+                    </pluginArtifact>
+                    <pluginId>grpc-java</pluginId>
+                    <protocArtifact>
+                        com.google.protobuf:protoc:3.12.0:exe:${os.detected.classifier}
+                    </protocArtifact>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>compile-custom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <version>0.6.1</version>
             </plugin>
         </plugins>
     </build>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="http://maven.apache.org/POM/4.0.0"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -61,36 +59,31 @@
         <dependency>
             <artifactId>grpc-netty-shaded</artifactId>
             <groupId>io.grpc</groupId>
-            <version>1.38.0</version>
         </dependency>
         <dependency>
             <artifactId>grpc-protobuf</artifactId>
             <groupId>io.grpc</groupId>
-            <version>1.38.0</version>
         </dependency>
         <dependency>
             <artifactId>grpc-stub</artifactId>
             <groupId>io.grpc</groupId>
-            <version>1.38.0</version>
         </dependency>
         <dependency>
             <artifactId>grpc-services</artifactId>
             <groupId>io.grpc</groupId>
-            <version>1.38.0</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-testing</artifactId>
             <scope>test</scope>
-            <version>1.38.0</version>
         </dependency>
         <dependency>
             <artifactId>grpc-grpclb</artifactId>
             <groupId>io.grpc</groupId>
             <scope>runtime</scope>
-            <version>1.38.0</version>
         </dependency>
-        <dependency> <!-- necessary for Java 9+ -->
+        <dependency>
+            <!-- necessary for Java 9+ -->
             <artifactId>annotations-api</artifactId>
             <groupId>org.apache.tomcat</groupId>
             <scope>provided</scope>
@@ -176,26 +169,8 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>protobuf-maven-plugin</artifactId>
-                <configuration>
-                    <pluginArtifact>
-                        io.grpc:protoc-gen-grpc-java:1.38.0:exe:${os.detected.classifier}
-                    </pluginArtifact>
-                    <pluginId>grpc-java</pluginId>
-                    <protocArtifact>
-                        com.google.protobuf:protoc:3.12.0:exe:${os.detected.classifier}
-                    </protocArtifact>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                            <goal>compile-custom</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <groupId>org.xolstice.maven.plugins</groupId>
-                <version>0.6.1</version>
+                <artifactId>protobuf-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>fmt-maven-plugin</artifactId>

--- a/workload/pom.xml
+++ b/workload/pom.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="http://maven.apache.org/POM/4.0.0"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -25,19 +23,17 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-api</artifactId>
-            <version>1.38.0</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
-            <version>1.38.0</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-protobuf</artifactId>
-            <version>1.38.0</version>
         </dependency>
-        <dependency> <!-- necessary for Java 9+ -->
+        <dependency>
+            <!-- necessary for Java 9+ -->
             <artifactId>annotations-api</artifactId>
             <groupId>org.apache.tomcat</groupId>
             <scope>provided</scope>
@@ -46,7 +42,6 @@
         <dependency>
             <artifactId>grpc-netty-shaded</artifactId>
             <groupId>io.grpc</groupId>
-            <version>1.38.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
@@ -79,25 +74,6 @@
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>0.6.1</version>
-                <configuration>
-                    <protoSourceRoot>../server/src/main/proto</protoSourceRoot>
-                    <protocArtifact>
-                        com.google.protobuf:protoc:3.3.0:exe:${os.detected.classifier}
-                    </protocArtifact>
-                    <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>
-                        io.grpc:protoc-gen-grpc-java:1.4.0:exe:${os.detected.classifier}
-                    </pluginArtifact>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                            <goal>compile-custom</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
Fixes #67. 

It's unclear to me why even though we explicitly specify the grpc-testing version as 1.38.0 in server dependencies, mvn compile of workload resolves it to 1.4.0. The conflict in the error message was:
```
[org.example:server:jar:1.0-SNAPSHOT -> com.google.cloud:google-cloud-spanner-jdbc:jar:2.0.2 -> io.grpc:grpc-core:jar:1.37.0,
 org.example:server:jar:1.0-SNAPSHOT -> com.google.cloud:google-cloud-spanner:jar:6.3.3 -> io.grpc:grpc-core:jar:1.37.0,
 org.example:server:jar:1.0-SNAPSHOT -> io.grpc:grpc-services:jar:1.38.0 -> io.grpc:grpc-core:jar:[1.38.0,1.38.0],
 org.example:server:jar:1.0-SNAPSHOT -> io.grpc:grpc-grpclb:jar:1.38.0 -> io.grpc:grpc-core:jar:[1.38.0,1.38.0],
 org.example:server:jar:1.0-SNAPSHOT -> io.grpc:grpc-testing:jar:1.40.0 -> io.grpc:grpc-core:jar:[1.40.0,1.40.0],
 io.grpc:grpc-netty-shaded:jar:1.38.0 -> io.grpc:grpc-core:jar:[1.38.0,1.38.0]]
```

Regardless, looks like manually specifying these versions isn't very scalable. So I have:
1. Used grpc-bom (as recommended by the grpc team) to simplify the inter-dependencies of grpc libraries, in the parent POM. 
2. The child modules simply depend on the artifacts without specifying the versions.
3. Moved the protobuf plugin, which was duplicated across the two child modules and has a dependency on grpc-version, to parent POM.

This setup fixes the issue and consolidates the version specification to a single location.

Additionally, I've added a ci-workflow to compile the workload module on push/pull in main branch.