### PR TITLE
Use jcommander instead of apache commons-cli in workload module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ for client libraries to work.
  
     ```
     $ mvn clean compile assembly:single
-    $ java -jar target/workload-1.0-SNAPSHOT-jar-with-dependencies.jar --address-name localhost --port 8080 --num-accounts 200 
+    $ java -jar target/workload-1.0-SNAPSHOT-jar-with-dependencies.jar \
+        --address-name localhost --port 8080 --thread-count 200 
     ```
 
 ## How to run the application tests

--- a/workload/pom.xml
+++ b/workload/pom.xml
@@ -54,12 +54,6 @@
             <version>3.8.0</version>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>
-            <version>1.4</version>
-        </dependency>
-
     </dependencies>
 
     <build>


### PR DESCRIPTION
Fixes #51 

For consistency with server module. Discussion around jcommander vs commons-cli at https://github.com/GoogleCloudPlatform/cloud-spanner-samples/pull/22#discussion_r681220662