### PR TITLE
Add a bash script to aid developers run emulator/server/workload

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ for client libraries to work.
 2. Bring up the FinAppServer hosting a grpc service.
 
     ```
-    $ bash run.sh java \
+    $ bash run.sh server java \
         --spanner_project_id=test-project --spanner_instance_id=test-instance \
         --spanner_database_id=test-database
     ```

--- a/README.md
+++ b/README.md
@@ -10,33 +10,18 @@ NOTE: Requires gcloud, mvn, grpc_cli installed.
 for client libraries to work.
 
     ```
-    $ gcloud emulators spanner start
-    $ gcloud config configurations create emulator
-    $ gcloud config set auth/disable_credentials true
-    $ gcloud config set project test-project
-    $ gcloud config set api_endpoint_overrides/spanner http://localhost:9020/
-    $ gcloud spanner instances create test-instance \
-        --config=emulator-config --description="Test Instance" --nodes=1
-    $ gcloud config set spanner/instance test-instance
-    $ gcloud spanner databases create test-database \
-        --ddl-file src/main/java/com/google/finapp/schema.sdl
-    $ export SPANNER_EMULATOR_HOST="localhost:9010"
+    $ bash run.sh emulator
     ```
 
-2. Bring up the FinAppServer hosting a grpc service from the `cloud-spanner-samples/server` directory in a separate terminal.
+2. Bring up the FinAppServer hosting a grpc service.
 
     ```
-    $ mvn clean compile assembly:single
-    $ java -jar target/server-1.0-SNAPSHOT-jar-with-dependencies.jar \
+    $ bash run.sh java \
         --spanner_project_id=test-project --spanner_instance_id=test-instance \
         --spanner_database_id=test-database
     ```
-> To run the application using the JDBC implementation instead of the default Java client implementation, add the flag.
-> ```
-> $ java -jar target/server-1.0-SNAPSHOT-jar-with-dependencies.jar \
-> --spanner_project_id=test-project --spanner_instance_id=test-instance \
-> --spanner_database_id=test-database --spanner_use_jdbc
-> ```
+> To run the application using the JDBC implementation, in the command above,
+substitute `java` with `jdbc`.
 
 3. Call RPCs using grpc_cli.
 
@@ -47,14 +32,13 @@ for client libraries to work.
 
 ## How to run the workload generator
 
-1. Run the application in a separate terminal.
+1. Bring up the finapp server using steps described above.
 
-2. In the `cloud-spanner-samples/workload` directory, run
+2. In a separate terminal, bring up the workload using the following command:
  
     ```
-    $ mvn clean compile assembly:single
-    $ java -jar target/workload-1.0-SNAPSHOT-jar-with-dependencies.jar \
-        --address-name localhost --port 8080 --thread-count 200 
+    $ bash run.sh workload \
+        --address-name localhost --port 8080 --num-accounts 200 
     ```
 
 ## How to run the application tests

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exit_with_help_msg() {
+  echo "Invalid command specified. Usage examples:
+  $ bash run.sh emulator
+  $ bash run.sh server java --spanner_project_id=test-project \
+      --spanner_instance_id=test-instance --spanner_database_id=test-database
+  $ bash run.sh server jdbc --spanner_project_id=test-project \
+      --spanner_instance_id=test-instance --spanner_database_id=test-database
+  " >&2
+  exit 1
+}
+
+teardown_previous_emulator() {
+  # There doesn't seem to be a convenient gcloud command such as:
+  # gcloud emulators spanner stop. So we kill the processes on the ports.
+  echo "Tearing down any emulator processes running previously."
+  fuser -k 9010/tcp
+  fuser -k 9020/tcp
+}
+
+run_and_configure_emulator() {
+  teardown_previous_emulator
+  gcloud emulators spanner start &
+  if ! gcloud config configurations create emulator; then
+    # If this isn't the first time this script is being executed,
+    # create emulator will fail. Just activate the emulator in that case.
+    gcloud config configurations activate emulator
+  fi
+  gcloud config set auth/disable_credentials true
+  gcloud config set project test-project
+  gcloud config set api_endpoint_overrides/spanner http://localhost:9020/
+  gcloud spanner instances create test-instance \
+    --config=emulator-config --description="Test Instance" --nodes=1
+  gcloud config set spanner/instance test-instance
+  gcloud spanner databases create test-database \
+    --ddl-file server/src/main/java/com/google/finapp/schema.sdl
+}
+
+run_server_java() {
+  mvn clean compile assembly:single -pl org.example:server
+  java -jar server/target/server-1.0-SNAPSHOT-jar-with-dependencies.jar $@
+}
+
+run_server_jdbc() {
+  mvn clean compile assembly:single -pl org.example:server
+  java -jar server/target/server-1.0-SNAPSHOT-jar-with-dependencies.jar \
+    --spanner_use_jdbc $@
+}
+
+run_server() {
+  declare -A -x servers_table=(
+    ['java']="run_server_java"
+    ['jdbc']="run_server_jdbc"
+  )
+  local servers="${!servers_table[@]}"
+
+  if [[ $# -lt 1 ]]; then exit_with_help_msg; fi
+
+  local server_type=${1}
+  shift
+  local fn_name=${servers_table[$server_type]}
+  if [[ $fn_name == '' ]]; then exit_with_help_msg; fi
+  if $fn_name $@; then return 0; else return 1; fi
+}
+
+main() {
+  declare -A -x command_table=(
+    ['emulator']="run_and_configure_emulator"
+    ['server']="run_server"
+  )
+  local commands="${!command_table[@]}"
+
+  if [[ $# -lt 1 ]]; then exit_with_help_msg; fi
+
+  local command=${1}
+  shift
+  local fn_name=${command_table[$command]}
+
+  if [[ $fn_name == '' ]]; then exit_with_help_msg; fi
+  if $fn_name $@; then return 0; else return 1; fi
+}
+
+main "$@"

--- a/run.sh
+++ b/run.sh
@@ -21,6 +21,8 @@ exit_with_help_msg() {
       --spanner_instance_id=test-instance --spanner_database_id=test-database
   $ bash run.sh server jdbc --spanner_project_id=test-project \
       --spanner_instance_id=test-instance --spanner_database_id=test-database
+  $ bash run.sh workload \
+       --address-name localhost --port 8080 --thread-count 200
   " >&2
   exit 1
 }
@@ -49,6 +51,7 @@ run_and_configure_emulator() {
   gcloud config set spanner/instance test-instance
   gcloud spanner databases create test-database \
     --ddl-file server/src/main/java/com/google/finapp/schema.sdl
+  export SPANNER_EMULATOR_HOST="localhost:9010"
 }
 
 run_server_java() {
@@ -78,10 +81,16 @@ run_server() {
   if $fn_name $@; then return 0; else return 1; fi
 }
 
+run_workload() {
+  mvn clean compile assembly:single -pl org.example:workload
+  java -jar workload/target/workload-1.0-SNAPSHOT-jar-with-dependencies.jar $a
+}
+
 main() {
   declare -A -x command_table=(
     ['emulator']="run_and_configure_emulator"
     ['server']="run_server"
+    ['workload']="run_workload"
   )
   local commands="${!command_table[@]}"
 

--- a/run.sh
+++ b/run.sh
@@ -13,6 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# A convenience script to help developers easily set up emulator, finapp server
+# and workload.
 
 exit_with_help_msg() {
   echo "Invalid command specified. Usage examples:


### PR DESCRIPTION
Running all the commands (to bring up emulator, configure it, compile and bring up server/workload) from the README is cumbersome and error prone. This script IMO should help reduce some of the toil involved in development.

Usage:
```
$ bash run.sh emulator
$ bash run.sh server java \
        --spanner_project_id=test-project --spanner_instance_id=test-instance \
        --spanner_database_id=test-database
$ bash run.sh server jdbc \
        --spanner_project_id=test-project --spanner_instance_id=test-instance \
        --spanner_database_id=test-database
$ bash run.sh workload \
        --address-name localhost --port 8080 --thread-count 200
```

Updated the README to use this script.