### PR TITLE
Fix registering grpc balancers for use in CloudShell

### DIFF
--- a/server/assembly-descriptor.xml
+++ b/server/assembly-descriptor.xml
@@ -1,0 +1,27 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+  <id>jar-with-dependencies</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <useProjectArtifact>false</useProjectArtifact>
+      <unpack>true</unpack>
+      <unpackOptions>
+        <excludes>
+          <exclude>io.grpc.LoadBalancerProvider</exclude>
+        </excludes>
+      </unpackOptions>
+    </dependencySet>
+  </dependencySets>
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.outputDirectory}</directory>
+      <outputDirectory>.</outputDirectory>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/server/src/main/resources/META-INF/services/io.grpc.LoadBalancerProvider
+++ b/server/src/main/resources/META-INF/services/io.grpc.LoadBalancerProvider
@@ -1,0 +1,3 @@
+io.grpc.grpclb.GrpclbLoadBalancerProvider
+io.grpc.internal.PickFirstLoadBalancerProvider
+io.grpc.util.SecretRoundRobinLoadBalancerProvider$Provider

--- a/server/src/main/resources/META-INF/services/io.grpc.NameResolverProvider
+++ b/server/src/main/resources/META-INF/services/io.grpc.NameResolverProvider
@@ -1,0 +1,1 @@
+io.grpc.internal.DnsNameResolverProvider


### PR DESCRIPTION
Relevant fix for java client samples: https://github.com/GoogleCloudPlatform/java-docs-samples/issues/2061