### PR TITLE
Disallow balance move to same account

### DIFF
--- a/server/src/main/java/com/google/finapp/FinAppService.java
+++ b/server/src/main/java/com/google/finapp/FinAppService.java
@@ -102,9 +102,17 @@ final class FinAppService extends FinAppGrpc.FinAppImplBase {
   public void moveAccountBalance(
       MoveAccountBalanceRequest request,
       StreamObserver<MoveAccountBalanceResponse> responseObserver) {
-    ImmutableMap<ByteArray, BigDecimal> accountBalances;
     ByteArray fromAccountId = ByteArray.copyFrom(request.getFromAccountId().toByteArray());
     ByteArray toAccountId = ByteArray.copyFrom(request.getToAccountId().toByteArray());
+    if (fromAccountId.equals(toAccountId)) {
+      responseObserver.onError(
+        Status.INVALID_ARGUMENT
+          .withDescription("\"To\" and \"from\" account IDs must be different")
+          .asException());
+      return;
+    }
+
+    ImmutableMap<ByteArray, BigDecimal> accountBalances;
     try {
       BigDecimal amount = getNonNegativeBigDecimal(request.getAmount());
       accountBalances = spannerDao.moveAccountBalance(fromAccountId, toAccountId, amount);

--- a/server/src/main/java/com/google/finapp/SpannerDaoImpl.java
+++ b/server/src/main/java/com/google/finapp/SpannerDaoImpl.java
@@ -105,11 +105,6 @@ final class SpannerDaoImpl implements SpannerDaoInterface {
   @Override
   public ImmutableMap<ByteArray, BigDecimal> moveAccountBalance(
       ByteArray fromAccountId, ByteArray toAccountId, BigDecimal amount) throws StatusException {
-    if (fromAccountId.equals(toAccountId)) {
-      throw Status.INVALID_ARGUMENT
-          .withDescription("\"To\" and \"from\" account IDs must be different")
-          .asException();
-    }
     try {
       return databaseClient
           .readWriteTransaction()

--- a/server/src/main/java/com/google/finapp/SpannerDaoImpl.java
+++ b/server/src/main/java/com/google/finapp/SpannerDaoImpl.java
@@ -105,6 +105,11 @@ final class SpannerDaoImpl implements SpannerDaoInterface {
   @Override
   public ImmutableMap<ByteArray, BigDecimal> moveAccountBalance(
       ByteArray fromAccountId, ByteArray toAccountId, BigDecimal amount) throws StatusException {
+    if (fromAccountId.equals(toAccountId)) {
+      throw Status.INVALID_ARGUMENT
+          .withDescription("\"To\" and \"from\" account IDs must be different")
+          .asException();
+    }
     ImmutableMap.Builder<ByteArray, BigDecimal> accountBalancesBuilder = ImmutableMap.builder();
     try {
       databaseClient

--- a/server/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
+++ b/server/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
@@ -109,11 +109,6 @@ final class SpannerDaoJDBCImpl implements SpannerDaoInterface {
 
   public ImmutableMap<ByteArray, BigDecimal> moveAccountBalance(
       ByteArray fromAccountId, ByteArray toAccountId, BigDecimal amount) throws StatusException {
-    if (fromAccountId.equals(toAccountId)) {
-      throw Status.INVALID_ARGUMENT
-          .withDescription("\"To\" and \"from\" account IDs must be different")
-          .asException();
-    }
     try (Connection connection = DriverManager.getConnection(this.connectionUrl)) {
       connection.setAutoCommit(false);
       ImmutableMap<ByteArray, AccountData> accountData =

--- a/server/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
+++ b/server/src/main/java/com/google/finapp/SpannerDaoJDBCImpl.java
@@ -109,6 +109,11 @@ final class SpannerDaoJDBCImpl implements SpannerDaoInterface {
 
   public ImmutableMap<ByteArray, BigDecimal> moveAccountBalance(
       ByteArray fromAccountId, ByteArray toAccountId, BigDecimal amount) throws StatusException {
+    if (fromAccountId.equals(toAccountId)) {
+      throw Status.INVALID_ARGUMENT
+          .withDescription("\"To\" and \"from\" account IDs must be different")
+          .asException();
+    }
     try (Connection connection = DriverManager.getConnection(this.connectionUrl)) {
       connection.setAutoCommit(false);
       ImmutableMap<ByteArray, AccountData> accountData =

--- a/server/src/test/java/com/google/finapp/FinAppIT.java
+++ b/server/src/test/java/com/google/finapp/FinAppIT.java
@@ -45,6 +45,8 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Scanner;
 import java.util.UUID;
+
+import org.apache.http.util.ByteArrayBuffer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -271,6 +273,25 @@ public class FinAppIT {
     assertThat(response.getFromAccountIdBalance()).isEqualTo("42");
     assertThat(response.getToAccountIdBalance()).isEqualTo("2");
   }
+
+  @Test
+  public void moveAccountBalance_sameAccount_throwsException() throws Exception {
+    ByteArray fromAccountId = UuidConverter.getBytesFromUuid(UUID.randomUUID());
+    ByteArray toAccountId = ByteArray.copyFrom(fromAccountId.toByteArray());
+
+    Exception e =
+        assertThrows(
+            io.grpc.StatusRuntimeException.class,
+            () ->
+                finAppService.moveAccountBalance(
+                    MoveAccountBalanceRequest.newBuilder()
+                        .setFromAccountId(ByteString.copyFrom(fromAccountId.toByteArray()))
+                        .setToAccountId(ByteString.copyFrom(toAccountId.toByteArray()))
+                        .setAmount("10")
+                        .build()));
+    assertThat(e.getMessage()).contains("\"To\" and \"from\" account IDs must be different");
+  }
+
 
   @Test
   public void moveAccountBalance_negativeAmount_throwsException() throws Exception {


### PR DESCRIPTION
Bugfix for `moveAccountBalance`, throw if `fromAccount` and `toAccount` are the same.