### PR TITLE
Turn down workload thread count (10 to 2)

### DIFF
--- a/workload/src/main/java/com/google/finapp/WorkloadMain.java
+++ b/workload/src/main/java/com/google/finapp/WorkloadMain.java
@@ -75,6 +75,6 @@ public final class WorkloadMain {
     @Parameter(
         names = {"--thread-count", "-t"},
         description = "Number of threads to use, to control parallelism.")
-    int threadCount = 10;
+    int threadCount = 2;
   }
 }


### PR DESCRIPTION
More sensible default, power users can turn it up.