### PR TITLE
bug: fix incompatible com.coveo:fmt-maven-plugin:2.11:format version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,8 +117,6 @@
                     <source>8</source>
                     <target>8</target>
                 </configuration>
-                <groupId>org.apache.maven.plugins</groupId>
-                <version>3.8.1</version>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -135,7 +133,7 @@
                     </execution>
                 </executions>
                 <groupId>com.coveo</groupId>
-                <version>2.11</version>
+                <version>2.9</version>
             </plugin>
             <plugin>
                 <artifactId>protobuf-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,8 @@
                     <source>8</source>
                     <target>8</target>
                 </configuration>
+                <groupId>org.apache.maven.plugins</groupId>
+                <version>3.8.1</version>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
According to https://github.com/coveooss/fmt-maven-plugin#using-with-java-8, the version 2.11 is only compatible with Java11. This project specifies maven compiler as `1.7`.