### PR TITLE
Use docker to start emulator

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -40,7 +40,8 @@ teardown_previous_emulator() {
 
 run_and_configure_emulator() {
   teardown_previous_emulator
-  gcloud emulators spanner start &
+  docker pull gcr.io/cloud-spanner-emulator/emulator
+  docker run -p 9010:9010 -p 9020:9020 gcr.io/cloud-spanner-emulator/emulator &
   if ! gcloud config configurations create emulator; then
     # If this isn't the first time this script is being executed,
     # create emulator will fail. Just activate the emulator in that case.

--- a/run.sh
+++ b/run.sh
@@ -41,7 +41,7 @@ teardown_previous_emulator() {
 run_and_configure_emulator() {
   teardown_previous_emulator
   docker pull gcr.io/cloud-spanner-emulator/emulator
-  docker run -p 9010:9010 -p 9020:9020 gcr.io/cloud-spanner-emulator/emulator &
+  docker run --detach -p 9010:9010 -p 9020:9020 gcr.io/cloud-spanner-emulator/emulator
   if ! gcloud config configurations create emulator; then
     # If this isn't the first time this script is being executed,
     # create emulator will fail. Just activate the emulator in that case.


### PR DESCRIPTION
Use the alternative docker way to start the emulator, making this compatible with the Kokoro VMs used for benchmarking tests.
https://cloud.google.com/spanner/docs/emulator#docker