### PR TITLE
Add empty CloudSpannerSampleApp in SDL

### DIFF
--- a/finance/server/src/main/java/com/google/finapp/schema.sdl
+++ b/finance/server/src/main/java/com/google/finapp/schema.sdl
@@ -44,4 +44,8 @@ CREATE TABLE CustomerRole (
 ) PRIMARY KEY (CustomerId, RoleId),
   INTERLEAVE IN PARENT Customer ON DELETE CASCADE;
 
+CREATE TABLE CloudSpannerSampleApp (
+  id INT64,
+) PRIMARY KEY (id);
+
 CREATE INDEX CustomerRoleByAccount ON CustomerRole(AccountId, CustomerId)

--- a/finance/server/src/main/java/com/google/finapp/schema.sdl
+++ b/finance/server/src/main/java/com/google/finapp/schema.sdl
@@ -44,8 +44,8 @@ CREATE TABLE CustomerRole (
 ) PRIMARY KEY (CustomerId, RoleId),
   INTERLEAVE IN PARENT Customer ON DELETE CASCADE;
 
-CREATE TABLE CloudSpannerSampleApp (
-  id INT64,
-) PRIMARY KEY (id);
+CREATE INDEX CustomerRoleByAccount ON CustomerRole(AccountId, CustomerId);
 
-CREATE INDEX CustomerRoleByAccount ON CustomerRole(AccountId, CustomerId)
+CREATE TABLE CloudSpannerSampleApp (
+  Id INT64 NOT NULL
+) PRIMARY KEY (Id)

--- a/finance/server/src/main/java/com/google/finapp/schema_pg.sdl
+++ b/finance/server/src/main/java/com/google/finapp/schema_pg.sdl
@@ -48,4 +48,8 @@ CREATE TABLE CustomerRole (
     REFERENCES Account(AccountId)
 ) INTERLEAVE IN PARENT Customer ON DELETE CASCADE;
 
+CREATE TABLE CloudSpannerSampleApp (
+  id INT64,
+) PRIMARY KEY (id);
+
 CREATE INDEX CustomerRoleByAccount ON CustomerRole(AccountId, CustomerId)

--- a/finance/server/src/main/java/com/google/finapp/schema_pg.sdl
+++ b/finance/server/src/main/java/com/google/finapp/schema_pg.sdl
@@ -48,8 +48,9 @@ CREATE TABLE CustomerRole (
     REFERENCES Account(AccountId)
 ) INTERLEAVE IN PARENT Customer ON DELETE CASCADE;
 
-CREATE TABLE CloudSpannerSampleApp (
-  id INT64,
-) PRIMARY KEY (id);
+CREATE INDEX CustomerRoleByAccount ON CustomerRole(AccountId, CustomerId);
 
-CREATE INDEX CustomerRoleByAccount ON CustomerRole(AccountId, CustomerId)
+CREATE TABLE "CloudSpannerSampleApp" (
+  Id BIGINT NOT NULL,
+  PRIMARY KEY (Id)
+)

--- a/finance/server/src/main/java/com/google/finapp/schema_pg.sdl
+++ b/finance/server/src/main/java/com/google/finapp/schema_pg.sdl
@@ -50,7 +50,7 @@ CREATE TABLE CustomerRole (
 
 CREATE INDEX CustomerRoleByAccount ON CustomerRole(AccountId, CustomerId);
 
-CREATE TABLE "CloudSpannerSampleApp" (
+CREATE TABLE CloudSpannerSampleApp (
   Id BIGINT NOT NULL,
   PRIMARY KEY (Id)
 )


### PR DESCRIPTION
Add stub `CloudSpannerSampleApp` tables to let the Cloud Spanner UI know that this is a sample app.